### PR TITLE
fix(ci): fix quality-gates.yml macOS stat flag and GITHUB_STEP_SUMMARY typo on Linux runners

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -56,7 +56,7 @@ jobs:
           echo "📦 Checking bundle size..."
           
           if [ -f dist/index.js ]; then
-            SIZE=$(stat -f%s dist/index.js)
+            SIZE=$(stat -c%s dist/index.js)
             SIZE_KB=$((SIZE / 1024))
             echo "Bundle size: ${SIZE_KB}KB"
             
@@ -142,13 +142,13 @@ jobs:
           fi
           
           if [ -f dist/index.js ]; then
-            SIZE=$(stat -f%s dist/index.js)
+            SIZE=$(stat -c%s dist/index.js)
             SIZE_KB=$((SIZE / 1024))
             echo "- Bundle Size: ${SIZE_KB}KB" >> $GITHUB_STEP_SUMMARY
           fi
           
           TODO_COUNT=$(grep -r "TODO\|FIXME\|HACK\|XXX" src/ --include="*.ts" --include="*.js" | wc -l || echo "0")
-          echo "- TODO Comments: $TODO_COUNT" >> $ITHUB_STEP_SUMMARY
+          echo "- TODO Comments: $TODO_COUNT" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
           echo "### 🎯 Quality Score" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- `quality-gates.yml`: replace `stat -f%s` (macOS BSD flag) with `stat -c%s` (Linux GNU flag) — fixes bundle size check on `ubuntu-latest` runners (2 occurrences)
- `quality-gates.yml`: fix `$ITHUB_STEP_SUMMARY` typo → `$GITHUB_STEP_SUMMARY`

## Test plan
- [ ] Verify bundle size check step succeeds on ubuntu-latest
- [ ] Verify quality report summary appears in GitHub Actions step summary