### PR TITLE
fix(ci): add missing id to validate-release-branch step

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate release branch name
+        id: validate
         run: |
           BRANCH="${{ github.head_ref }}"
           if [[ ! "$BRANCH" =~ ^release/v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then


### PR DESCRIPTION
Adds `id: validate` to the 'Validate release branch name' step so subsequent steps can reference `steps.validate.outputs.version`. Without this id, `steps.validate.outputs.version` resolves to empty string, causing the 'Check version format' step to fail immediately.