### PR TITLE
fix(ci): Align security-monitoring workflow with CI setup

### DIFF
--- a/.github/workflows/security-monitoring.yml
+++ b/.github/workflows/security-monitoring.yml
@@ -21,11 +21,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
-        run: npm install --legacy-peer-deps
+        run: rm -f package-lock.json && npm install --legacy-peer-deps
 
       - name: Audit production dependencies
         run: npm audit --audit-level=high --omit=dev
@@ -53,11 +53,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
+      - name: Setup siza-gen
+        uses: ./.github/actions/setup-siza-gen
+
       - name: Install dependencies
-        run: npm install --legacy-peer-deps
+        run: rm -f package-lock.json && npm install --legacy-peer-deps
+
+      - name: Build
+        run: npm run build
 
       - name: Run tests with coverage
         run: npm run test:coverage
@@ -106,6 +112,20 @@ jobs:
             const { owner, repo } = context.repo;
             const date = new Date().toISOString().split('T')[0];
             const title = `Security/Coverage Monitoring Alert - ${date}`;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'monitoring,security',
+              per_page: 5,
+            });
+            const duplicate = existing.data.find(i => i.title === title);
+            if (duplicate) {
+              console.log(`Issue "${title}" already exists (#${duplicate.number}), skipping.`);
+              return;
+            }
+
             const body = [
               '## Monitoring Alert',
               '',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix security-monitoring.yml: add `setup-siza-gen` action, Node 22, `npm run build` before tests
+- Add duplicate issue detection to monitoring alert notifications
+
 ## [0.8.1] - 2026-02-25
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Fix daily security-monitoring workflow that has been failing since siza-gen extraction
- Add `setup-siza-gen` composite action to coverage-monitoring job
- Fix Node version 24 → 22 (matches CI)
- Add `npm run build` before `test:coverage` (quality tests load built JS)
- Add `rm -f package-lock.json` before install (avoids stale lockfile 403s)
- Add duplicate issue detection so the notify-team job doesn't create redundant alerts

Fixes #68, #69

## Test plan
- [x] Pre-push hook: lint, format, typecheck, 394 tests pass
- [ ] CI passes on this PR
- [ ] Trigger workflow_dispatch to verify monitoring runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)