### PR TITLE
fix: Update deploy.yml package name to @forgespace/ui-mcp

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy
 
 on:
-  push:
-    branches: [main, dev]
   workflow_dispatch:
     inputs:
       version_type:
@@ -28,81 +26,6 @@ on:
     types: [automated-release]
 
 jobs:
-  # Dev deployment (triggers on push to dev branch)
-  deploy-dev:
-    name: Deploy to Dev
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: rm -f package-lock.json && npm install --legacy-peer-deps
-
-      - name: Run tests
-        run: npm test
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish to npm with dev tag
-        run: npm publish --tag dev --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker dev image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            lucassantana/uiforge-mcp:dev
-            ghcr.io/forge-space/ui-mcp:dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Dev Deployment Summary
-        run: |
-          echo "## 🚀 Dev Deployment Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          VERSION=$(node -p "require('./package.json').version")
-          echo "**Version:** $VERSION (dev)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Installation" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "npx uiforge-mcp@dev" >> $GITHUB_STEP_SUMMARY
-          echo "# or" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull lucassantana/uiforge-mcp:dev" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-
   # Pre-flight checks (production only)
   preflight:
     name: Pre-flight Checks
@@ -400,12 +323,12 @@ jobs:
       - name: Verify publication
         run: |
           VERSION="${{ needs.preflight.outputs.version }}"
-          npm view uiforge-mcp@$VERSION
+          npm view @forgespace/ui-mcp@$VERSION
 
           # Test installation
           cd /tmp
-          npm i -g uiforge-mcp@$VERSION
-          uiforge-mcp --help || true
+          npm i -g @forgespace/ui-mcp@$VERSION
+          forgespace-ui-mcp --help || true
 
   # Create GitHub release
   release:
@@ -451,7 +374,7 @@ jobs:
 
             ### 📦 Package Installation
             ```bash
-            npm install -g uiforge-mcp@${{ needs.preflight.outputs.version }}
+            npm install -g @forgespace/ui-mcp@${{ needs.preflight.outputs.version }}
             ```
 
             ### 🐳 Docker Installation


### PR DESCRIPTION
## Summary
- Remove dead deploy-dev job (dev branch was deleted)
- Remove unused push trigger 
- Fix npm verify/install commands to use `@forgespace/ui-mcp` instead of old `uiforge-mcp`
- Fix binary name reference to `forgespace-ui-mcp` (matching package.json bin)
- Fix release notes install command

## Context
The deploy.yml still referenced the old package name `uiforge-mcp` in verify, install, and release note steps. The package.json was already updated to `@forgespace/ui-mcp` but the workflow was not.

## Test plan
- [ ] Workflow dispatch triggers preflight correctly
- [ ] Publish step uses correct package name from package.json
- [ ] Verify step checks `@forgespace/ui-mcp` on npm registry