### PR TITLE
fix: Use env context for Docker secrets check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -255,6 +255,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [preflight, qa]
     if: needs.preflight.outputs.should_publish == 'true'
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
       - uses: actions/checkout@v4
 
@@ -262,7 +264,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        if: github.event.inputs.dry_run != 'true' && github.event.client_payload.dry_run != 'true' && secrets.DOCKER_USERNAME != ''
+        if: github.event.inputs.dry_run != 'true' && github.event.client_payload.dry_run != 'true' && env.DOCKER_USERNAME != ''
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
## Summary
Fix GitHub Actions workflow validation error: `secrets` context can't be used in step-level `if` conditions. Maps `DOCKER_USERNAME` to job-level `env` and checks `env.DOCKER_USERNAME` instead.

## Context
Deploy workflow dispatch failed with: `Unrecognized named-value: 'secrets'`. This was introduced in PR #87.

## Test plan
- [ ] Workflow dispatch no longer fails with parse error
- [ ] Docker login skips gracefully when secrets are not configured