### PR TITLE
fix: Use env context for Docker login secrets check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -255,6 +255,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [preflight, qa]
     if: needs.preflight.outputs.should_publish == 'true'
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
       - uses: actions/checkout@v4
 
@@ -262,7 +264,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        if: github.event.inputs.dry_run != 'true' && github.event.client_payload.dry_run != 'true' && secrets.DOCKER_USERNAME != ''
+        if: github.event.inputs.dry_run != 'true' && github.event.client_payload.dry_run != 'true' && env.DOCKER_USERNAME != ''
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
## Summary
- GitHub Actions `if` conditions cannot access `secrets.*` context directly (always evaluates as empty string)
- Moved `DOCKER_USERNAME` to job-level `env` block and reference via `env.DOCKER_USERNAME` in the condition

## Test plan
- [ ] CI passes on branch
- [ ] Deploy workflow Docker login step correctly skips when no Docker credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)