### PR TITLE
fix: Restore npm install for native binary platform compat

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,7 +157,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: rm -f package-lock.json && npm install --legacy-peer-deps
 
       - name: Run full validation
         run: npm run validate:all
@@ -224,7 +224,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: rm -f package-lock.json && npm install --legacy-peer-deps
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary
Restores `rm -f package-lock.json && npm install --legacy-peer-deps` for QA and Build jobs. `npm ci` installs from lockfile (generated on macOS arm64) which misses `@resvg/resvg-js-linux-x64-gnu` on Ubuntu CI runners.

## Context
The v0.13.1 deploy failed at QA because `npm ci` doesn't resolve platform-specific optional dependencies that weren't in the original lockfile.

## Test plan
- [ ] Trigger deploy after merge — QA tests should pass on linux