### PR TITLE
fix: Decouple release job from Docker build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -341,8 +341,8 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [preflight, qa, build, docker]
-    if: needs.preflight.outputs.should_publish == 'true' && (github.event.inputs.create_release == 'true' || github.event.client_payload.create_release == 'true')
+    needs: [preflight, qa, build]
+    if: always() && needs.build.result == 'success' && (github.event.inputs.create_release == 'true' || github.event.client_payload.create_release == 'true')
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
Remove Docker build as a dependency for the release job. Docker is optional (requires DOCKER_USERNAME/DOCKER_PASSWORD secrets), so a Docker failure shouldn't block GitHub release creation.

## Test plan
- [ ] Deploy workflow creates GitHub release even when Docker build fails