### PR TITLE
chore: Bump version to v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-03-01
+
+### Added
+
+- Jest mocks for `sharp` and `@resvg/resvg-js` native modules — fixes CI test failures on linux-x64
+- First npm publish: `npm install -g @forgespace/ui-mcp@0.14.0`
+
+### Fixed
+
+- CI deploy pipeline: Docker login condition uses `env` context instead of `secrets` (PR #88, #89)
+- CI native binary compatibility: `npm install` step for platform-specific deps (PR #90)
+- 6 test suites that crashed on CI due to missing platform-specific native binaries
+
 ## [0.13.0] - 2026-03-01
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@forgespace/ui-mcp",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@forgespace/ui-mcp",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@forgespace/siza-gen": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgespace/ui-mcp",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "AI-driven UI generation via Model Context Protocol. Generate React, Next.js, Vue, Angular applications from natural language.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Sync repo version with npm publish (v0.14.0 published to npm)
- Add CHANGELOG entry for v0.14.0 covering CI fixes and first npm publish

## Context
The deploy workflow's Update Version job can't push directly to main due to rulesets.
This PR syncs the repo version manually after successful npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)