### PR TITLE
chore(deps): bump @forgespace/core to ^1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@forgespace/core": "^1.1.4",
+        "@forgespace/core": "^1.6.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/fs-extra": "^11.0.1",
         "@types/jest": "^30.0.0",
@@ -1144,7 +1144,9 @@
       }
     },
     "node_modules/@forgespace/core": {
-      "version": "1.1.4",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@forgespace/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-1YC8nQqv74TqvbEfJRimoY/okbVxMlkWSLB8YTXpVNN+DyoL656Pp0bV3sg3ca10N8mCd17lN6IUagOgI+JZ0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1156,7 +1158,10 @@
         "semver": "^7.5.4"
       },
       "bin": {
-        "forge-patterns": "dist/cli.js"
+        "forge-features": "dist/patterns/idp/feature-toggles/cli.js",
+        "forge-patterns": "dist/cli.js",
+        "forge-policy": "dist/patterns/idp/policy-engine/cli.js",
+        "forge-scorecard": "dist/patterns/idp/scorecards/cli.js"
       },
       "engines": {
         "node": ">=22.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@forgespace/core": "^1.1.4",
+    "@forgespace/core": "^1.6.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary
- Bumps `@forgespace/core` from `^1.1.4` to `^1.6.0`
- Picks up `forge-features` CLI and `scoreGeneratedCode()` post-gen scorer

## Test plan
- [x] Pre-commit gate passed (lint, tsc, tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)