### PR TITLE
feat: add DEBUG/VERBOSE logging for MCP tool handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-03-07
+
+### Added
+
+- **Debug/verbose logging** — Set `DEBUG=true` or `VERBOSE=true` to enable structured stderr logging with timing, params, and output size (closes #115)
+  - `src/lib/debug.ts`: `debugLogger`, `debugTiming()`, `withDebug()` wrapper, `isVerbose()`
+  - Integrated into `generate_ui_component` and `generate_form` handlers
+  - 5 new unit tests for debug module
+
 ## [0.15.0] - 2026-03-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgespace/ui-mcp",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "AI-driven UI generation via Model Context Protocol. Generate React, Next.js, Vue, Angular applications from natural language.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__tests__/lib/debug.unit.test.ts
+++ b/src/__tests__/lib/debug.unit.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach, jest } from '@jest/globals';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+describe('debug module', () => {
+  const origEnv = process.env;
+
+  afterEach(() => {
+    process.env = origEnv;
+    jest.resetModules();
+  });
+
+  async function loadModule(envDebug?: string) {
+    jest.resetModules();
+    if (envDebug !== undefined) {
+      process.env = { ...origEnv, DEBUG: envDebug };
+    } else {
+      const { DEBUG: _, VERBOSE: __, ...rest } = origEnv;
+      process.env = rest;
+    }
+    return import('../../lib/debug.js');
+  }
+
+  it('isVerbose returns true when DEBUG=true', async () => {
+    const { isVerbose } = await loadModule('true');
+    expect(isVerbose()).toBe(true);
+  });
+
+  it('isVerbose returns false when DEBUG not set', async () => {
+    const { isVerbose } = await loadModule();
+    expect(isVerbose()).toBe(false);
+  });
+
+  it('debugTiming returns elapsed ms', async () => {
+    const { debugTiming } = await loadModule('true');
+    const end = debugTiming('test-op');
+    const ms = end();
+    expect(typeof ms).toBe('number');
+    expect(ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('withDebug passes through handler when debug off', async () => {
+    const { withDebug } = await loadModule();
+    const handler = (async () => ({
+      content: [{ type: 'text' as const, text: 'ok' }],
+    })) as () => Promise<CallToolResult>;
+
+    const wrapped = withDebug('test_tool', handler);
+    expect(wrapped).toBe(handler);
+  });
+
+  it('withDebug wraps handler when debug on', async () => {
+    const { withDebug } = await loadModule('true');
+    const result: CallToolResult = {
+      content: [{ type: 'text', text: 'ok' }],
+    };
+    const calls: unknown[] = [];
+    const handler = async (args: Record<string, unknown>) => {
+      calls.push(args);
+      return result;
+    };
+
+    const wrapped = withDebug('test_tool', handler);
+    expect(wrapped).not.toBe(handler);
+
+    const out = await wrapped({ component_type: 'button', framework: 'react' });
+    expect(out).toEqual(result);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ component_type: 'button', framework: 'react' });
+  });
+});

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -1,0 +1,56 @@
+import pino from 'pino';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+const isDebug = process.env.DEBUG === 'true' || process.env.DEBUG === '1' || process.env.VERBOSE === 'true';
+
+export const debugLogger = pino(
+  {
+    name: 'uiforge-debug',
+    level: isDebug ? 'debug' : 'silent',
+    timestamp: pino.stdTimeFunctions.isoTime,
+  },
+  pino.destination(2)
+);
+
+export function isVerbose(): boolean {
+  return isDebug;
+}
+
+export function debugTiming(label: string): () => number {
+  const start = performance.now();
+  debugLogger.debug({ label }, 'start: %s', label);
+  return () => {
+    const ms = Math.round(performance.now() - start);
+    debugLogger.debug({ label, ms }, 'done: %s (%dms)', label, ms);
+    return ms;
+  };
+}
+
+type ToolHandler<T> = (args: T) => Promise<CallToolResult>;
+
+export function withDebug<T extends Record<string, unknown>>(
+  toolName: string,
+  handler: ToolHandler<T>
+): ToolHandler<T> {
+  if (!isDebug) return handler;
+
+  return async (args: T) => {
+    const start = performance.now();
+    const paramKeys = Object.keys(args).filter((k) => args[k] !== undefined && args[k] !== '');
+    debugLogger.debug({ tool: toolName, params: paramKeys }, '[%s] called with: %s', toolName, paramKeys.join(', '));
+
+    const result = await handler(args);
+    const ms = Math.round(performance.now() - start);
+
+    const outputSize = JSON.stringify(result).length;
+    debugLogger.debug(
+      { tool: toolName, ms, outputSize, isError: result.isError },
+      '[%s] completed in %dms (output: %d bytes)',
+      toolName,
+      ms,
+      outputSize
+    );
+
+    return result;
+  };
+}

--- a/src/tools/generate-form.ts
+++ b/src/tools/generate-form.ts
@@ -13,6 +13,7 @@ import {
   type IGeneration,
 } from '@forgespace/siza-gen';
 import { withBrandContext } from '../lib/brand-context.js';
+import { debugLogger, debugTiming } from '../lib/debug.js';
 
 const logger = createLogger('generate-form');
 
@@ -711,6 +712,11 @@ export function registerGenerateForm(server: McpServer): void {
       visual_style: _visualStyle,
     }) => {
       return withBrandContext(brand_identity, async () => {
+        const endTotal = debugTiming('generate_form');
+        debugLogger.debug(
+          { form_type, framework, validation_library, component_library, multi_step },
+          '[generate_form] params'
+        );
         try {
           initializeRegistry();
           const ctx = designContextStore.get();
@@ -777,6 +783,15 @@ export function registerGenerateForm(server: McpServer): void {
             'Files:',
             ...files.map((f) => `  ${f.path}`),
           ].join('\n');
+
+          const totalMs = endTotal();
+          debugLogger.debug(
+            { tool: 'generate_form', totalMs, fileCount: files.length, fieldCount: resolvedFields.length },
+            '[generate_form] total: %dms, %d files, %d fields',
+            totalMs,
+            files.length,
+            resolvedFields.length
+          );
 
           return {
             content: [

--- a/src/tools/generate-ui-component.ts
+++ b/src/tools/generate-ui-component.ts
@@ -34,6 +34,7 @@ import {
 import { auditStyles } from '../lib/style-audit.js';
 import { withBrandContext } from '../lib/brand-context.js';
 import { extractDesignFromUrl } from '../lib/design-extractor.js';
+import { debugLogger, debugTiming } from '../lib/debug.js';
 
 // Track generation count for pattern promotion
 // Note: This is incremented after successful generation to avoid race conditions
@@ -194,7 +195,12 @@ export function registerGenerateUiComponent(server: McpServer): void {
       brand_identity,
     }) => {
       return withBrandContext(brand_identity, async () => {
-        // Initialize the component registry on first use
+        const endTotal = debugTiming('generate_ui_component');
+        debugLogger.debug(
+          { component_type, framework, component_library, mood, industry, visual_style, skip_ml },
+          '[generate_ui_component] params'
+        );
+
         initializeRegistry();
 
         const warnings: string[] = [];
@@ -230,6 +236,13 @@ export function registerGenerateUiComponent(server: McpServer): void {
             }
           }
         }
+
+        debugLogger.debug(
+          { enhanced: enhancedPromptText.length, original: component_type.length },
+          '[generate_ui_component] prompt enhanced (%d → %d chars)',
+          component_type.length,
+          enhancedPromptText.length
+        );
 
         // RAG: Semantic search for similar components and relevant rules
         let ragContext: {
@@ -339,6 +352,14 @@ export function registerGenerateUiComponent(server: McpServer): void {
           ragOptions || undefined,
           registryMatch,
           component_library
+        );
+
+        const totalChars = files.reduce((s, f) => s + f.content.length, 0);
+        debugLogger.debug(
+          { fileCount: files.length, totalChars, registryMatch: !!registryMatch },
+          '[generate_ui_component] generated %d files (%d chars)',
+          files.length,
+          totalChars
         );
 
         // ML: Quality scoring with RAG enhancement (unless skip_ml)
@@ -467,6 +488,14 @@ export function registerGenerateUiComponent(server: McpServer): void {
         ]
           .filter(Boolean)
           .join('\n');
+
+        const totalMs = endTotal();
+        debugLogger.debug(
+          { tool: 'generate_ui_component', totalMs, qualityScore: qualityScore?.score },
+          '[generate_ui_component] total: %dms, quality: %s',
+          totalMs,
+          qualityScore?.score ?? 'n/a'
+        );
 
         return {
           content: [


### PR DESCRIPTION
## Summary
Set `DEBUG=true` or `VERBOSE=true` to enable structured stderr logging with timing, params, and output size for MCP tool handlers. Closes #115.

## Changes
- **`src/lib/debug.ts`** (new): `debugLogger`, `debugTiming()`, `withDebug()` wrapper, `isVerbose()`
- **`generate_ui_component`**: Logs params, prompt enhancement, file generation, quality score, total timing
- **`generate_form`**: Logs params, file count, field count, total timing
- All output goes to stderr via `pino.destination(2)` — no MCP stdout pollution

## Usage
```bash
DEBUG=true npx @forgespace/ui-mcp  # enables verbose logging
```

## Test plan
- [x] 5 new unit tests for debug module
- [x] Full test suite passes (pre-push gate: lint + format + tsc + tests + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)