### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.17.0] - 2026-03-08
 
 ### Added
 
-- **`assess_legacy_codebase` MCP tool** — Assess legacy codebase health using @forgespace/core migration module (5 collectors: dependencies, architecture, security, quality, migration-readiness)
-- **`generate_migration_plan` MCP tool** — Generate phased migration roadmap with strategy detection (strangler-fig, branch-by-abstraction, parallel-run, lift-and-shift)
-- Bumped `@forgespace/core` to ^1.10.1 (moved from devDependencies to dependencies)
+- **`assess_legacy_codebase` MCP tool** — Assess legacy codebase health via `forge-ai-init` CLI. Returns health score (0-100), grade (A-F), migration strategy, and detailed findings
+- **`generate_migration_plan` MCP tool** — Generate phased migration roadmap with quality gates (40% → 60% → 80%) and strategy detection (strangler-fig, branch-by-abstraction, parallel-run)
 
 ## [0.16.0] - 2026-03-07
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgespace/ui-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "AI-driven UI generation via Model Context Protocol. Generate React, Next.js, Vue, Angular applications from natural language.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Fixes CHANGELOG to correctly reference `forge-ai-init` CLI instead of `@forgespace/core`
- Bumps version 0.16.0 → 0.17.0
- Migration assessment MCP tools (`assess_legacy_codebase`, `generate_migration_plan`) already on main from PR #124

## Test plan
- [x] 517 tests passing (40 suites)
- [x] Build succeeds (391 KB bundle)
- [x] CHANGELOG accurately describes tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)