### PR TITLE
fix(ci): restore monitoring dashboard CodeQL upload permissions

### DIFF
--- a/.github/workflows/monitoring-dashboard.yml
+++ b/.github/workflows/monitoring-dashboard.yml
@@ -24,7 +24,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
   issues: write
   pull-requests: read
 
@@ -230,6 +229,9 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- CI: Added `security-events: write` permission to `Monitoring Dashboard`
-  workflow so scheduled CodeQL analysis can upload SARIF results successfully.
+- CI: Added job-scoped `security-events: write` permission to the
+  `Monitoring Dashboard` security scan so scheduled CodeQL analysis can upload
+  SARIF results successfully.
 
 ## [0.18.0] - 2026-03-08
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ npm test                  # 437 tests, 35 suites
 npm run validate          # lint + format + typecheck + test
 ```
 
-Scheduled monitoring runs that execute CodeQL require `security-events: write`
-workflow permission for SARIF upload.
+Scheduled monitoring runs that execute CodeQL require job-scoped
+`security-events: write` permission for SARIF upload.
 
 ## License
 


### PR DESCRIPTION
## Summary\n- fix scheduled `Monitoring Dashboard` failures on `main`\n- root cause: CodeQL SARIF upload was denied (`Resource not accessible by integration`)\n- add `security-events: write` to workflow permissions so CodeQL analyze can publish results\n\n## Changes\n- update \.github/workflows/monitoring-dashboard.yml permissions\n- update README with workflow permission note\n- update CHANGELOG with unreleased CI fix entry\n\n## Validation\n- `npm run lint:check` (warnings only, no errors)\n- `npm run format:check`\n- `npm test`\n- `npm run build`\n