### PR TITLE
ci: Harden security monitoring scheduled coverage workflow

### DIFF
--- a/.github/workflows/security-monitoring.yml
+++ b/.github/workflows/security-monitoring.yml
@@ -65,19 +65,11 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./coverage/coverage-final.json,./coverage/lcov.info
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-
       - name: Generate coverage report
         run: |
           echo "## Coverage Monitoring Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Codecov upload is intentionally skipped in scheduled monitoring to avoid third-party action download failures." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [ -f coverage/coverage-summary.json ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI: Added job-scoped `security-events: write` permission to the
   `Monitoring Dashboard` security scan so scheduled CodeQL analysis can upload
   SARIF results successfully.
+- CI: Hardened scheduled `Security Monitoring` coverage job by removing
+  Codecov action usage from the scheduled workflow path, preventing false
+  failures caused by third-party action download errors.
 
 ## [0.18.0] - 2026-03-08
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ npm run validate          # lint + format + typecheck + test
 Scheduled monitoring runs that execute CodeQL require job-scoped
 `security-events: write` permission for SARIF upload.
 
+The scheduled `Security Monitoring` workflow intentionally skips Codecov upload
+and relies on local coverage summary generation to reduce false alerting from
+third-party action download instability.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- remove Codecov action usage from scheduled Security Monitoring coverage job
- keep daily security scan and coverage summary generation unchanged
- prevent false monitoring alerts caused by third-party action download failures (401 during setup)

## Validation
- YAML parse: 

## Review
- Mandatory review completed: no blocking findings
- Residual risk: schedule still depends on npm install/test health, which is expected monitoring behavior

Closes #131