### PR TITLE
chore: release v0.19.0 — MCP Registry metadata and tag-driven publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-03-15
+
 ### Added
 
-- MCP Registry metadata via `server.json` and npm `mcpName` for official
-  registry submission readiness.
-- Tag-driven publish automation for npm provenance + MCP Registry publishing.
-- Weekly MCP Registry status workflow that updates one distribution issue with
-  npm/registry drift and discovery state.
+- **MCP Registry metadata** — `server.json` with MCP Registry schema and npm
+  `mcpName` field for official registry submission readiness.
+- **Tag-driven publish pipeline** — `publish.yml` replaces `deploy.yml` +
+  `release-automation.yml`: push `v*` tag → npm publish with provenance → MCP
+  Registry publish via GitHub OIDC → GitHub release.
+- **Weekly MCP Registry status** — `mcp-registry-status.yml` refreshes one
+  tracking issue with npm/registry drift and discovery state.
+- **Registry validation script** — `registry:check` validates server.json ↔
+  package.json alignment before publish (version, name, mcpName, files).
 
 ### Changed
 
 - npm distribution docs now use the scoped package
   `@forgespace/ui-mcp` and the `forgespace-ui-mcp` binary consistently.
-- MCP server runtime version is now read from `package.json` at startup instead
-  of being hardcoded, so it always matches the published version.
-- `server.json` now uses the current MCP Registry schema field names so
-  release automation and registry validation stay aligned.
+- MCP server runtime version is now read from `package.json` at startup via
+  `createRequire`, so it always matches the published version automatically.
+- `server.json` uses the current MCP Registry schema field names so release
+  automation and registry validation stay aligned.
+- Bundle size: 403 KB (unchanged)
+- Test count: 529 tests across 45 suites (unchanged)
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,8 @@
 ```bash
 NODE_OPTIONS=--experimental-vm-modules npm run build
 NODE_OPTIONS=--experimental-vm-modules npm test
+npm run registry:check          # validate server.json ↔ package.json
+npm run validate:all            # lint + format + tsc + test + build
 ```
 
 ## Project
@@ -13,14 +15,15 @@ NODE_OPTIONS=--experimental-vm-modules npm test
 - All AI/ML, generators, registry, feedback, and quality code lives in
   `@forgespace/siza-gen`
 - GitHub: Forge-Space/ui-mcp, default branch: `main`
+- npm: `@forgespace/ui-mcp`, binary: `forgespace-ui-mcp`
 - Bundle: ~403 KB (tools, services, resources only)
 
 ## Architecture
 
 ```
-siza-mcp (this repo)              @forgespace/siza-gen
+@forgespace/ui-mcp (this repo)    @forgespace/siza-gen
 ├── src/index.ts (MCP server)     ├── ml/        (embeddings, quality, training)
-├── tools/     (32 tool defs)     ├── generators/ (react, vue, angular, svelte, html)
+├── tools/     (33 tool files)    ├── generators/ (react, vue, angular, svelte, html)
 ├── services/  (figma, analysis)  ├── registry/   (502 snippets, compositions, packs)
 ├── resources/ (MCP resources)    ├── feedback/   (self-learning, pattern promotion)
 └── lib/       (browser, image)   └── quality/    (anti-generic rules, diversity)
@@ -38,14 +41,22 @@ siza-mcp (this repo)              @forgespace/siza-gen
 - 45 test suites, 529 tests (tool-level + integration)
 - siza-gen has 343 additional tests for AI/registry internals
 
+## Distribution
+
+- `server.json` — MCP Registry metadata (io.github.forge-space/ui-mcp)
+- `publish.yml` — tag-driven: push `v*` → npm publish + MCP Registry + GitHub release
+- `mcp-registry-status.yml` — weekly tracking issue with npm/registry drift
+- `registry:check` — pre-publish validation (server.json ↔ package.json alignment)
+
 ## What Stays Here
 
-- `src/tools/` — 21 MCP tool definitions (schema + handler glue)
+- `src/tools/` — 33 tool files (schema + handler glue)
 - `src/services/` — Figma, analysis, generation, design services
 - `src/resources/` — MCP resource providers
 - `src/lib/` — browser-scraper, design-extractor, figma-client, image-analyzer,
   image-renderer, pattern-detector, prototype-builder, style-audit,
   tailwind-mapper, templates/
+- `scripts/` — registry-check.mjs, mcp-registry-status.mjs
 
 ## Gotchas
 
@@ -55,3 +66,5 @@ siza-mcp (this repo)              @forgespace/siza-gen
   subagent work
 - `fail()` unavailable in Jest ESM — use `throw new Error()`
 - All AI/registry imports must come from `@forgespace/siza-gen`, not `./lib/`
+- MCP server version is dynamic (reads package.json via createRequire)
+- When bumping version: update both `package.json` and `server.json`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@forgespace/ui-mcp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@forgespace/ui-mcp",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@forgespace/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forgespace/ui-mcp",
   "mcpName": "io.github.forge-space/ui-mcp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "AI-driven UI generation via Model Context Protocol. Generate React, Next.js, Vue, Angular applications from natural language.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.forge-space/ui-mcp",
   "description": "Forge Space UI MCP server for full-stack UI and backend generation. Ships as a stdio npm package for MCP clients and registry discovery.",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "repository": {
     "url": "https://github.com/Forge-Space/ui-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@forgespace/ui-mcp",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- Bump version to 0.19.0 in `package.json` and `server.json`
- Move CHANGELOG [Unreleased] section to [0.19.0] release header

## What's in v0.19.0

- **MCP Registry metadata** — `server.json` + `mcpName` for official registry submission
- **Tag-driven publish pipeline** — `publish.yml` replaces old deploy + release workflows
- **Weekly registry status** — automated issue tracking npm/registry drift
- **Registry validation** — `registry:check` script for pre-publish validation
- **Dynamic MCP version** — server reads version from `package.json` at startup

## Post-merge

After merging, tag and push to trigger the publish pipeline:

```bash
git tag -a v0.19.0 -m "Release v0.19.0"
git push origin v0.19.0
```

This will trigger `publish.yml` which:
1. Validates release contract (`registry:check` + `validate:all`)
2. Publishes to npm with provenance
3. Publishes to MCP Registry via GitHub OIDC
4. Creates GitHub release with auto-generated notes

## Verification

- 45 suites, 529 tests passing
- Build: 402.90 KB