### PR TITLE
fix(ci): make publish pipeline resilient to already-published npm versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,26 @@ jobs:
 
       - run: npm ci --legacy-peer-deps
       - run: npm run build
-      - run: npm publish --provenance --access public
+
+      - name: Publish to npm
+        id: npm-publish
+        continue-on-error: true
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Check npm publish result
+        run: |
+          if [ "${{ steps.npm-publish.outcome }}" = "failure" ]; then
+            VERSION=$(node -p "require('./package.json').version")
+            # Check if version already exists on npm (not a real failure)
+            if npm view "@forgespace/ui-mcp@${VERSION}" version 2>/dev/null; then
+              echo "::warning::npm already has v${VERSION} — skipping publish"
+            else
+              echo "::error::npm publish failed for a reason other than duplicate version"
+              exit 1
+            fi
+          fi
 
       - name: Install MCP publisher
         run: |
@@ -66,7 +83,7 @@ jobs:
   release:
     name: Create GitHub release
     needs: publish
-    if: github.event_name == 'push'
+    if: always() && needs.publish.result != 'cancelled' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Make `npm publish` step use `continue-on-error: true` with a follow-up check that distinguishes "already published" (warning) from real failures (error)
- Allow GitHub release creation even if the publish job had non-fatal issues

## Problem

When v0.19.0 was tagged, the publish workflow failed because npm already had that version. This blocked the MCP Registry publish and GitHub release creation, even though the package was already on npm.

## Fix

The publish step now:
1. Attempts `npm publish` with `continue-on-error`
2. Checks if failure was due to duplicate version (warning) vs real error (exit 1)
3. Continues to MCP Registry publish regardless
4. Release job runs with `if: always()` so it creates the GitHub release even if publish had issues