### PR TITLE
fix(ci): rewrite publish workflow with pre-check npm version detection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,25 +49,26 @@ jobs:
       - run: npm ci --legacy-peer-deps
       - run: npm run build
 
+      - name: Check if version already on npm
+        id: npm-check
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # Use unauthenticated curl to avoid scoped-package auth issues
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://registry.npmjs.org/@forgespace%2fui-mcp/${VERSION}")
+          if [ "$STATUS" = "200" ]; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::v${VERSION} already on npm — skipping publish"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
-        id: npm-publish
-        continue-on-error: true
+        if: steps.npm-check.outputs.already_published == 'false'
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Check npm publish result
-        run: |
-          if [ "${{ steps.npm-publish.outcome }}" = "failure" ]; then
-            VERSION=$(node -p "require('./package.json').version")
-            # Check if version already exists on npm (not a real failure)
-            if npm view "@forgespace/ui-mcp@${VERSION}" version 2>/dev/null; then
-              echo "::warning::npm already has v${VERSION} — skipping publish"
-            else
-              echo "::error::npm publish failed for a reason other than duplicate version"
-              exit 1
-            fi
-          fi
 
       - name: Install MCP publisher
         run: |
@@ -93,3 +94,4 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          make_latest: true


### PR DESCRIPTION
## Problem

The previous `continue-on-error` + outcome-check pattern for npm publish was fragile:

1. `npm publish` exits 1 with E403 when version already exists on npm
2. The check step ran `npm view "@forgespace/ui-mcp@${VERSION}" version` **with `NODE_AUTH_TOKEN` still in env**
3. For scoped packages with auth configured, `npm view` exits non-zero → check incorrectly treats it as a real failure
4. MCP Registry publish never runs; release job runs anyway due to `if: always()`

The package was published successfully (verified: 0.19.0 and 0.20.0 are on npm), but CI showed red.

## Fix

Replace `continue-on-error` with a **pre-check** approach:

1. Use `curl` to check the unauthenticated npm registry API — no auth token involved, reliable 200/404
2. If version exists → skip `npm publish` entirely (notice, not error)  
3. If version missing → publish normally
4. MCP Registry publish always runs after (idempotent)
5. `make_latest: true` added to gh-release action

This is cleaner and eliminates the fragile outcome-check step entirely.