### PR TITLE
fix: truncate server.json description + registry:check validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-03-15
+
+### Fixed
+
+- Truncate server.json description to 73 chars (MCP Registry enforces max 100 chars; the 136-char
+  value caused 422 validation on every publish, breaking MCP Registry distribution)
+- registry:check script now validates server.json description length before publish
+
+
 ## [0.22.0] - 2026-03-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@forgespace/ui-mcp",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@forgespace/ui-mcp",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "dependencies": {
         "@forgespace/siza-gen": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forgespace/ui-mcp",
   "mcpName": "io.github.forge-space/ui-mcp",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "AI-driven UI generation via Model Context Protocol. Generate React, Next.js, Vue, Angular applications from natural language.",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/registry-check.mjs
+++ b/scripts/registry-check.mjs
@@ -66,6 +66,10 @@ function collectFindings(pkg, server, packPaths, publishedVersions) {
   if (publishedVersions[pkg.version]) {
     warnings.push(`npm already has published version ${pkg.version}; bump before the next release tag.`);
   }
+  // MCP Registry enforces description <= 100 chars
+  if (server.description && server.description.length > 100) {
+    errors.push(`server.json description is ${server.description.length} chars (max 100 for MCP Registry).`);
+  }
   return { errors, warnings };
 }
 

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.forge-space/ui-mcp",
-  "description": "Forge Space UI MCP server for full-stack UI and backend generation. Ships as a stdio npm package for MCP clients and registry discovery.",
-  "version": "0.22.0",
+  "description": "Forge Space MCP server for UI and backend generation via stdio transport.",
+  "version": "0.22.1",
   "repository": {
     "url": "https://github.com/Forge-Space/ui-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@forgespace/ui-mcp",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
MCP Registry 422: description > 100 chars. Fixed to 73 chars. Added length check to registry:check.