### PR TITLE
fix: correct MCP Registry name casing (io.github.Forge-Space/ui-mcp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-03-15
+
+### Fixed
+
+- Fix MCP Registry name casing: use io.github.Forge-Space/ui-mcp (capital F and S)
+  to match GitHub OIDC org token — previous lowercase caused 403 Forbidden on every publish
+- Also update package.json mcpName to match
+
+
 ## [0.22.1] - 2026-03-15
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@forgespace/ui-mcp",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@forgespace/ui-mcp",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "MIT",
       "dependencies": {
         "@forgespace/siza-gen": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forgespace/ui-mcp",
-  "mcpName": "io.github.forge-space/ui-mcp",
-  "version": "0.22.1",
+  "mcpName": "io.github.Forge-Space/ui-mcp",
+  "version": "0.22.2",
   "description": "AI-driven UI generation via Model Context Protocol. Generate React, Next.js, Vue, Angular applications from natural language.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.forge-space/ui-mcp",
+  "name": "io.github.Forge-Space/ui-mcp",
   "description": "Forge Space MCP server for UI and backend generation via stdio transport.",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "repository": {
     "url": "https://github.com/Forge-Space/ui-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@forgespace/ui-mcp",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
MCP Registry 403: OIDC token grants io.github.Forge-Space/* but server.json used lowercase. Fix casing, bump to v0.22.2.