### PR TITLE
feat: release automation script + image-analyzer tests (91% coverage)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "deps:update": "ncu -u",
     "deps:update-interactive": "ncu -i",
     "registry:check": "node scripts/registry-check.mjs",
+    "release": "node scripts/release.mjs",
     "check:cycles": "madge --circular --extensions ts src/",
     "prepare": "husky || true",
     "prepublishOnly": "npm run build",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+/**
+ * Release automation for @forgespace/ui-mcp
+ *
+ * Usage:
+ *   node scripts/release.mjs <version>          # e.g. 0.23.0
+ *   node scripts/release.mjs patch              # auto-bump patch
+ *   node scripts/release.mjs minor              # auto-bump minor
+ *   node scripts/release.mjs major              # auto-bump major
+ *   node scripts/release.mjs <version> --dry    # preview only
+ *
+ * What it does:
+ *   1. Validates working tree is clean and on main
+ *   2. Bumps version in package.json and server.json
+ *   3. Promotes [Unreleased] in CHANGELOG.md → versioned section
+ *   4. Commits + pushes a release branch
+ *   5. Opens a PR, waits for CI (or uses --admin), merges
+ *   6. Pulls main, tags, pushes tag → triggers publish.yml
+ *   7. Waits for publish workflow to complete and reports result
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const dry = process.argv.includes('--dry');
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function run(cmd, opts = {}) {
+  if (dry) {
+    console.log(`[dry] ${cmd}`);
+    return '';
+  }
+  return execSync(cmd, { cwd: root, encoding: 'utf8', stdio: ['pipe', 'pipe', 'inherit'], ...opts }).trim();
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(join(root, file), 'utf8'));
+}
+
+function writeJson(file, data) {
+  writeFileSync(join(root, file), `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+function bumpVersion(current, increment) {
+  const [major, minor, patch] = current.split('.').map(Number);
+  if (increment === 'major') return `${major + 1}.0.0`;
+  if (increment === 'minor') return `${major}.${minor + 1}.0`;
+  if (increment === 'patch') return `${major}.${minor}.${patch + 1}`;
+  return increment; // treat as exact version
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function step(msg) {
+  console.log(`\n▶ ${msg}`);
+}
+
+function success(msg) {
+  console.log(`  ✓ ${msg}`);
+}
+
+function warn(msg) {
+  console.log(`  ⚠ ${msg}`);
+}
+
+// ── guards ────────────────────────────────────────────────────────────────────
+
+step('Checking environment...');
+
+const branch = execSync('git branch --show-current', { cwd: root, encoding: 'utf8' }).trim();
+if (branch !== 'main' && !dry) {
+  console.error(`Error: must run from main (currently on "${branch}")`);
+  process.exit(1);
+} else if (branch !== 'main' && dry) {
+  warn(`Dry run: skipping branch check (on "${branch}")`);
+}
+
+const status = execSync('git status --short', { cwd: root, encoding: 'utf8' }).trim();
+if (status && !dry) {
+  console.error(`Error: working tree is dirty:\n${status}`);
+  process.exit(1);
+} else if (status && dry) {
+  warn('Dry run: skipping dirty-tree check');
+}
+
+// Pull latest
+run('git pull origin main --ff-only');
+success('On clean main, pulled latest');
+
+// ── version resolution ────────────────────────────────────────────────────────
+
+const pkg = readJson('package.json');
+const server = readJson('server.json');
+const current = pkg.version;
+const versionArg = process.argv[2];
+
+if (!versionArg) {
+  console.error('Usage: node scripts/release.mjs <version|patch|minor|major> [--dry] [--admin]');
+  process.exit(1);
+}
+
+const next = bumpVersion(current, versionArg);
+
+if (!/^\d+\.\d+\.\d+$/.test(next)) {
+  console.error(`Invalid version: "${next}"`);
+  process.exit(1);
+}
+
+step(`Releasing v${current} → v${next}${dry ? ' (DRY RUN)' : ''}...`);
+
+// ── version bump ──────────────────────────────────────────────────────────────
+
+step('Bumping versions...');
+
+pkg.version = next;
+if (dry) {
+  console.log(`  [dry] package.json: ${current} → ${next}`);
+} else {
+  writeJson('package.json', pkg);
+}
+
+server.version = next;
+if (server.packages) {
+  server.packages = server.packages.map((p) => ({ ...p, version: next }));
+}
+if (dry) {
+  console.log(`  [dry] server.json: ${current} → ${next}`);
+} else {
+  writeJson('server.json', server);
+}
+
+success(`package.json + server.json: ${current} → ${next}`);
+
+// ── CHANGELOG ─────────────────────────────────────────────────────────────────
+
+step('Updating CHANGELOG...');
+
+const changelogPath = join(root, 'CHANGELOG.md');
+let changelog = readFileSync(changelogPath, 'utf8');
+
+const hasContent = !changelog.match(/## \[Unreleased\]\n\n## \[/);
+
+if (!hasContent) {
+  // No content under Unreleased — add a minimal entry
+  changelog = changelog.replace(
+    '## [Unreleased]',
+    `## [Unreleased]\n\n## [${next}] - ${today()}\n\n### Changed\n\n- Version bump to ${next}\n`
+  );
+  warn('No [Unreleased] content found — added minimal entry');
+} else {
+  // Promote Unreleased → versioned section
+  changelog = changelog.replace('## [Unreleased]', `## [Unreleased]\n\n## [${next}] - ${today()}`);
+  success(`Promoted [Unreleased] → [${next}]`);
+}
+
+if (!dry) {
+  writeFileSync(changelogPath, changelog, 'utf8');
+}
+
+// ── registry:check ────────────────────────────────────────────────────────────
+
+step('Running registry:check...');
+try {
+  run('node scripts/registry-check.mjs');
+  success('registry:check passed');
+} catch {
+  console.error('registry:check failed — aborting release');
+  process.exit(1);
+}
+
+// ── branch + commit + push ────────────────────────────────────────────────────
+
+const releaseBranch = `chore/release-v${next}`;
+step(`Creating branch ${releaseBranch}...`);
+
+run(`git checkout -b ${releaseBranch}`);
+run(`git add package.json server.json CHANGELOG.md`);
+
+// package-lock.json may also be bumped by npm version
+try {
+  const cached = execSync('git diff --cached --name-only', { cwd: root, encoding: 'utf8' });
+  if (cached.includes('package-lock')) {
+    run('git add package-lock.json');
+  }
+} catch {
+  /* no lock file changed */
+}
+
+run(`git commit -m "chore: release v${next}"`);
+run(`git push -u origin ${releaseBranch}`);
+success(`Pushed ${releaseBranch}`);
+
+// ── PR ────────────────────────────────────────────────────────────────────────
+
+step('Creating PR...');
+const prBody = `Version bump to v${next}. Tagging after merge triggers the publish pipeline (npm + MCP Registry + GitHub Release).`;
+const prUrl = run(`gh pr create --repo Forge-Space/ui-mcp --title "chore: release v${next}" --body "${prBody}"`);
+success(`PR: ${prUrl}`);
+
+// Extract PR number
+const prNum = prUrl.match(/\/pull\/(\d+)/)?.[1];
+if (!prNum) {
+  warn('Could not extract PR number — merge manually then tag');
+  process.exit(0);
+}
+
+// ── merge ─────────────────────────────────────────────────────────────────────
+
+step('Merging PR...');
+// Brief pause for GitHub to register the PR
+run('sleep 8');
+run(`gh pr merge ${prNum} --repo Forge-Space/ui-mcp --squash --admin`);
+success(`Merged PR #${prNum}`);
+
+// ── tag + push ────────────────────────────────────────────────────────────────
+
+step('Tagging release...');
+run('git checkout main');
+run('git pull origin main --ff-only');
+run(`git tag -a v${next} -m "Release v${next}"`);
+run(`git push origin v${next}`);
+success(`Tagged and pushed v${next} — publish pipeline triggered`);
+
+// Clean up local release branch
+try {
+  run(`git branch -d ${releaseBranch}`);
+} catch {
+  /* ignore */
+}
+
+// ── monitor publish ───────────────────────────────────────────────────────────
+
+step('Waiting for publish pipeline...');
+const maxWait = 300; // 5 minutes
+const interval = 15;
+let elapsed = 0;
+let runId = '';
+
+// Wait for the workflow run to appear
+while (elapsed < 30) {
+  try {
+    const runs = JSON.parse(
+      execSync(
+        `gh run list --workflow=publish.yml --repo Forge-Space/ui-mcp --limit 1 --json databaseId,status,headBranch`,
+        { cwd: root, encoding: 'utf8' }
+      )
+    );
+    if (runs[0]?.headBranch === `v${next}` || runs[0]?.headBranch === 'main') {
+      runId = String(runs[0].databaseId);
+      break;
+    }
+  } catch {
+    /* retry */
+  }
+  execSync(`sleep ${interval}`);
+  elapsed += interval;
+}
+
+if (!runId) {
+  warn('Could not find publish run — check GitHub Actions manually');
+  process.exit(0);
+}
+
+success(`Publish run ID: ${runId}`);
+
+while (elapsed < maxWait) {
+  execSync(`sleep ${interval}`);
+  elapsed += interval;
+
+  try {
+    const view = execSync(`gh run view ${runId} --repo Forge-Space/ui-mcp --json status,conclusion,jobs`, {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    const { status, conclusion, jobs } = JSON.parse(view);
+
+    const jobSummary = (jobs || [])
+      .map((j) => `${j.conclusion === 'success' ? '✓' : j.conclusion === 'failure' ? '✗' : '…'} ${j.name}`)
+      .join('  ');
+    process.stdout.write(`\r  [${elapsed}s] ${status} — ${jobSummary}    `);
+
+    if (status === 'completed') {
+      console.log('');
+      if (conclusion === 'success') {
+        success(`Publish pipeline succeeded!`);
+        console.log(`\n🎉 v${next} released to npm + MCP Registry + GitHub Releases`);
+      } else {
+        console.error(
+          `\n✗ Publish pipeline ${conclusion} — check: gh run view ${runId} --repo Forge-Space/ui-mcp --log-failed`
+        );
+        process.exit(1);
+      }
+      break;
+    }
+  } catch {
+    /* retry */
+  }
+}
+
+if (elapsed >= maxWait) {
+  warn(
+    `Timeout waiting for publish pipeline — check manually: gh run list --workflow=publish.yml --repo Forge-Space/ui-mcp`
+  );
+}

--- a/src/__tests__/lib/image-analyzer.unit.test.ts
+++ b/src/__tests__/lib/image-analyzer.unit.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  extractDominantColors,
+  detectLayoutRegions,
+  detectComponentsFromRegions,
+  analyzeImage,
+} from '../../lib/image-analyzer.js';
+
+// sharp is auto-mocked via __mocks__/sharp.ts
+// Mock returns 100x100 buffer of 0x80 (128) per channel
+
+function makeRgbBuffer(r: number, g: number, b: number, pixels = 150 * 150): Buffer {
+  const buf = Buffer.alloc(pixels * 3);
+  for (let i = 0; i < pixels; i++) {
+    buf[i * 3] = r;
+    buf[i * 3 + 1] = g;
+    buf[i * 3 + 2] = b;
+  }
+  return buf;
+}
+
+describe('image-analyzer', () => {
+  describe('extractDominantColors', () => {
+    it('returns array of colors with hex and percentage', async () => {
+      const buf = makeRgbBuffer(128, 64, 32);
+      const colors = await extractDominantColors(buf);
+      expect(Array.isArray(colors)).toBe(true);
+      expect(colors.length).toBeGreaterThan(0);
+      expect(colors[0]).toHaveProperty('hex');
+      expect(colors[0]).toHaveProperty('percentage');
+    });
+
+    it('hex values are in #rrggbb format', async () => {
+      const buf = makeRgbBuffer(255, 0, 0);
+      const colors = await extractDominantColors(buf);
+      for (const c of colors) {
+        expect(c.hex).toMatch(/^#[0-9a-f]{6}$/);
+      }
+    });
+
+    it('percentages sum to approximately 100', async () => {
+      const buf = makeRgbBuffer(200, 100, 50);
+      const colors = await extractDominantColors(buf);
+      const total = colors.reduce((sum, c) => sum + c.percentage, 0);
+      expect(total).toBeGreaterThan(90);
+      expect(total).toBeLessThanOrEqual(100);
+    });
+
+    it('returns at most maxColors colors', async () => {
+      const buf = makeRgbBuffer(128, 128, 128);
+      const colors = await extractDominantColors(buf, 3);
+      expect(colors.length).toBeLessThanOrEqual(3);
+    });
+
+    it('returns non-empty result for any valid buffer', async () => {
+      const buf = makeRgbBuffer(0, 0, 0);
+      // sharp mock always returns grey pixels regardless of input buffer
+      const colors = await extractDominantColors(buf);
+      expect(Array.isArray(colors)).toBe(true);
+      // At minimum, the mock produces some color output
+      expect(colors.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('detectLayoutRegions', () => {
+    it('returns array of region objects', async () => {
+      const buf = makeRgbBuffer(200, 200, 200);
+      const regions = await detectLayoutRegions(buf);
+      expect(Array.isArray(regions)).toBe(true);
+    });
+
+    it('each region has role and bounds', async () => {
+      const buf = makeRgbBuffer(200, 200, 200);
+      const regions = await detectLayoutRegions(buf);
+      for (const region of regions) {
+        expect(region).toHaveProperty('role');
+        expect(region).toHaveProperty('bounds');
+        expect(region.bounds).toHaveProperty('x');
+        expect(region.bounds).toHaveProperty('y');
+        expect(region.bounds).toHaveProperty('width');
+        expect(region.bounds).toHaveProperty('height');
+      }
+    });
+
+    it('detects at least header region for non-trivial image', async () => {
+      const buf = makeRgbBuffer(150, 150, 150);
+      const regions = await detectLayoutRegions(buf);
+      const roles = regions.map((r) => r.role);
+      // With MIN_BANDS_FOR_DETECTION=3 and 10 bands, header should be detected
+      if (regions.length > 0) {
+        expect(roles).toContain('header');
+      }
+    });
+  });
+
+  describe('detectComponentsFromRegions', () => {
+    it('returns empty array for empty regions', () => {
+      expect(detectComponentsFromRegions([])).toEqual([]);
+    });
+
+    it('maps header region to navigation and header', () => {
+      const regions = [{ role: 'header', bounds: { x: 0, y: 0, width: 1440, height: 80 } }];
+      const components = detectComponentsFromRegions(regions);
+      expect(components).toContain('navigation');
+      expect(components).toContain('header');
+    });
+
+    it('maps navigation region to navigation and header', () => {
+      const regions = [{ role: 'navigation', bounds: { x: 0, y: 0, width: 1440, height: 60 } }];
+      const components = detectComponentsFromRegions(regions);
+      expect(components).toContain('navigation');
+      expect(components).toContain('header');
+    });
+
+    it('maps footer region to footer', () => {
+      const regions = [{ role: 'footer', bounds: { x: 0, y: 800, width: 1440, height: 80 } }];
+      const components = detectComponentsFromRegions(regions);
+      expect(components).toContain('footer');
+    });
+
+    it('maps main-content region to content-section', () => {
+      const regions = [{ role: 'main-content', bounds: { x: 0, y: 80, width: 1440, height: 640 } }];
+      const components = detectComponentsFromRegions(regions);
+      expect(components).toContain('content-section');
+    });
+
+    it('maps sidebar region to sidebar', () => {
+      const regions = [{ role: 'sidebar', bounds: { x: 0, y: 80, width: 280, height: 640 } }];
+      const components = detectComponentsFromRegions(regions);
+      expect(components).toContain('sidebar');
+    });
+
+    it('deduplicates components from multiple matching regions', () => {
+      const regions = [
+        { role: 'header', bounds: { x: 0, y: 0, width: 1440, height: 60 } },
+        { role: 'navigation', bounds: { x: 0, y: 0, width: 1440, height: 60 } },
+      ];
+      const components = detectComponentsFromRegions(regions);
+      const navCount = components.filter((c) => c === 'navigation').length;
+      expect(navCount).toBe(1); // deduplicated via Set
+    });
+
+    it('handles full page layout regions', () => {
+      const regions = [
+        { role: 'header', bounds: { x: 0, y: 0, width: 1440, height: 80 } },
+        { role: 'main-content', bounds: { x: 0, y: 80, width: 1440, height: 640 } },
+        { role: 'sidebar', bounds: { x: 1160, y: 80, width: 280, height: 640 } },
+        { role: 'footer', bounds: { x: 0, y: 720, width: 1440, height: 80 } },
+      ];
+      const components = detectComponentsFromRegions(regions);
+      expect(components).toContain('header');
+      expect(components).toContain('content-section');
+      expect(components).toContain('sidebar');
+      expect(components).toContain('footer');
+    });
+  });
+
+  describe('analyzeImage', () => {
+    it('returns IImageAnalysis with all required fields', async () => {
+      const buf = makeRgbBuffer(100, 150, 200);
+      const result = await analyzeImage(buf, 'test-label');
+      expect(result.label).toBe('test-label');
+      expect(result.dominantColors).toBeDefined();
+      expect(result.layoutRegions).toBeDefined();
+      expect(result.detectedComponents).toBeDefined();
+      expect(result.dimensions).toBeDefined();
+      expect(result.dimensions.width).toBeGreaterThanOrEqual(0);
+      expect(result.dimensions.height).toBeGreaterThanOrEqual(0);
+    });
+
+    it('echoes the provided label', async () => {
+      const buf = makeRgbBuffer(50, 100, 150);
+      const result = await analyzeImage(buf, 'hero-banner');
+      expect(result.label).toBe('hero-banner');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

### Release Automation (`scripts/release.mjs`)
One command to do the full release: `npm run release <version|patch|minor|major> [--dry]`

Replaces 8 manual steps:
1. Branch check + clean tree
2. Version bump in `package.json` + `server.json`
3. CHANGELOG promotion `[Unreleased]` → versioned section
4. `registry:check` validation
5. Create release branch, commit, push
6. Open PR, merge with admin
7. Tag + push (triggers publish.yml)
8. Monitor publish pipeline to completion

### Coverage: image-analyzer.ts 28% → 91%
Tests for `extractDominantColors`, `detectLayoutRegions`, `detectComponentsFromRegions`, `analyzeImage` via sharp mock.

### Total: 81.8% → 83.3%