### PR TITLE
chore: release v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-03-15
+
+### Changed
+
+- Version bump to 0.24.1
+
+
 ## [0.24.0] - 2026-03-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forgespace/ui-mcp",
   "mcpName": "io.github.Forge-Space/ui-mcp",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "AI-driven UI generation via Model Context Protocol. Generate React, Next.js, Vue, Angular applications from natural language.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Forge-Space/ui-mcp",
   "description": "Forge Space MCP server for UI and backend generation via stdio transport.",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "repository": {
     "url": "https://github.com/Forge-Space/ui-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@forgespace/ui-mcp",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Version bump to v0.24.1. Tagging after merge triggers the publish pipeline (npm + MCP Registry + GitHub Release).