### PR TITLE
test: improve branch coverage for assess-legacy and generate-migration-plan

### DIFF
--- a/src/__tests__/tools/assess-legacy.unit.test.ts
+++ b/src/__tests__/tools/assess-legacy.unit.test.ts
@@ -2,6 +2,7 @@ import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 const mockExecFileSync = jest.fn<() => string>();
 
@@ -9,7 +10,7 @@ jest.unstable_mockModule('node:child_process', () => ({
   execFileSync: mockExecFileSync,
 }));
 
-const { handleAssessLegacy } = await import('../../tools/assess-legacy.js');
+const { handleAssessLegacy, registerAssessLegacy } = await import('../../tools/assess-legacy.js');
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `mcp-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -103,6 +104,91 @@ describe('assess_legacy_codebase tool', () => {
     );
     expect(legacyFindings.length).toBeGreaterThanOrEqual(1);
 
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('formats findings with file and line number', () => {
+    const reportWithFile = {
+      ...fakeReport,
+      findings: [
+        { severity: 'warning', title: 'Issue in file', file: 'src/index.ts', line: 42 },
+        { severity: 'info', title: 'Issue without line', file: 'src/utils.ts' },
+      ],
+    };
+    mockExecFileSync.mockReturnValue(JSON.stringify(reportWithFile));
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    const report = handleAssessLegacy({ project_dir: dir }) as Record<string, unknown>;
+    expect(report.findings).toBeDefined();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('handles report with no categories', () => {
+    const reportNoCategories = {
+      overallScore: 50,
+      overallGrade: 'C',
+      migrationReadiness: 'needs-work',
+      migrationStrategy: 'strangler-fig',
+    };
+    mockExecFileSync.mockReturnValue(JSON.stringify(reportNoCategories));
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    const report = handleAssessLegacy({ project_dir: dir }) as Record<string, unknown>;
+    expect(report.overallScore).toBe(50);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('registers tool on server', () => {
+    const server = new McpServer({ name: 'test', version: '0.0.1' });
+    expect(() => registerAssessLegacy(server)).not.toThrow();
+    const tools = (server as unknown as { _registeredTools: Record<string, unknown> })._registeredTools;
+    expect(tools['assess_legacy_codebase']).toBeDefined();
+  });
+
+  it('registers and invokes handler with findings containing file and line', async () => {
+    const reportWithFileLine = {
+      overallScore: 60,
+      overallGrade: 'C',
+      migrationReadiness: 'needs-work',
+      migrationStrategy: 'strangler-fig',
+      categories: [{ category: 'code-quality', score: 60, grade: 'C', findings: 1 }],
+      findings: [
+        { severity: 'high', title: 'Bad pattern', file: 'src/app.ts', line: 10 },
+        { severity: 'medium', title: 'No file here' },
+      ],
+    };
+    mockExecFileSync.mockReturnValue(JSON.stringify(reportWithFileLine));
+    const server = new McpServer({ name: 'test', version: '0.0.1' });
+    registerAssessLegacy(server);
+    const tools = (
+      server as unknown as { _registeredTools: Record<string, { handler: (...a: unknown[]) => Promise<unknown> }> }
+    )._registeredTools;
+    const handler = tools['assess_legacy_codebase']?.handler;
+    expect(handler).toBeDefined();
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    const result = (await handler({ project_dir: dir })) as { content: Array<{ text: string }> };
+    expect(result).toHaveProperty('content');
+    expect(result.content[0].text).toContain('src/app.ts:10');
+    expect(result.content[0].text).toContain('No file here');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('handles handler error gracefully', async () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('CLI failed');
+    });
+    const server = new McpServer({ name: 'test', version: '0.0.1' });
+    registerAssessLegacy(server);
+    const tools = (
+      server as unknown as { _registeredTools: Record<string, { handler: (...a: unknown[]) => Promise<unknown> }> }
+    )._registeredTools;
+    const handler = tools['assess_legacy_codebase']?.handler;
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    const result = (await handler({ project_dir: dir })) as { isError: boolean; content: Array<{ text: string }> };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Assessment failed');
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/__tests__/tools/generate-migration-plan.unit.test.ts
+++ b/src/__tests__/tools/generate-migration-plan.unit.test.ts
@@ -129,4 +129,63 @@ describe('generate_migration_plan tool', () => {
     expect(Array.isArray(result.content)).toBe(true);
     rmSync(dir, { recursive: true, force: true });
   });
+
+  it('includes critical findings section when severity is critical', () => {
+    const criticalReport = {
+      ...fakeReport,
+      migrationStrategy: 'strangler-fig',
+      findings: [
+        { severity: 'critical', title: 'Security vulnerability', detail: 'CVE-2023-1234' },
+        { severity: 'high', title: 'Outdated dep', detail: 'express 3.x EOL' },
+      ],
+    };
+    mockExecFileSync.mockReturnValue(JSON.stringify(criticalReport));
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    const plan = handleGenerateMigrationPlan({ project_dir: dir });
+    expect(plan).toContain('Critical');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('includes file reference in findings when file property exists', () => {
+    const reportWithFile = {
+      ...fakeReport,
+      findings: [
+        { severity: 'high', title: 'Issue in file', file: 'src/index.ts' },
+        { severity: 'medium', title: 'No file' },
+      ],
+    };
+    mockExecFileSync.mockReturnValue(JSON.stringify(reportWithFile));
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    const plan = handleGenerateMigrationPlan({ project_dir: dir });
+    expect(plan).toContain('src/index.ts');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('uses strategy name as fallback for unknown strategy', () => {
+    const unknownStrategyReport = {
+      ...fakeReport,
+      migrationStrategy: 'custom-unknown-strategy',
+    };
+    mockExecFileSync.mockReturnValue(JSON.stringify(unknownStrategyReport));
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    const plan = handleGenerateMigrationPlan({ project_dir: dir });
+    expect(plan).toContain('custom-unknown-strategy');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('uses detail as fallback when finding has no title', () => {
+    const reportNoTitle = {
+      ...fakeReport,
+      findings: [{ severity: 'high', detail: 'Only detail, no title' }],
+    };
+    mockExecFileSync.mockReturnValue(JSON.stringify(reportNoTitle));
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: {} }));
+    const plan = handleGenerateMigrationPlan({ project_dir: dir });
+    expect(plan).toContain('Only detail, no title');
+    rmSync(dir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary

- Extended `assess-legacy.unit.test.ts` with 5 new tests covering: handler registration, findings with file+line, findings without file, no categories/findings, error catch block
- Extended `generate-migration-plan.unit.test.ts` with 4 new tests covering: critical severity findings, findings with file property, unknown strategy fallback, detail-only findings (no title)

## Coverage Impact

- Branches: **85.09% → 85.32%** (+0.23%)
- Tests: **823 → 832** (+9 tests)
- `assess-legacy.ts`: 72.7% → ~95% branches
- `generate-migration-plan.ts`: 64.7% → ~85% branches