### PR TITLE
fix(ci): allow manual MCP registry republish for ui-mcp

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
   publish:
     name: Publish npm package and MCP metadata
     needs: validate
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Why
Issue #167 reports MCP registry metadata lagging behind npm (`0.24.5` published, registry showing `0.22.2`). The current Publish workflow only runs registry publishing on tag pushes, so there is no clean way to re-run registry sync without cutting a new release.

## What changed
- Updated `.github/workflows/publish.yml` so the `publish` job also runs on `workflow_dispatch`.
- Kept existing npm guard behavior: if the current version is already on npm, npm publish is skipped, but MCP registry publish still runs.

## Expected outcome
- Maintainers can manually dispatch the Publish workflow to republish MCP metadata for the current version.
- This provides a non-release path to resolve issue #167.