### PR TITLE
chore: adopt org-level PR governance and stale management

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,10 @@
+name: PR Governance
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+# Security: No user-controlled inputs used in run: commands.
+
+jobs:
+  governance:
+    uses: Forge-Space/.github/.github/workflows/reusable-pr-governance.yml@main

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,12 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+# Security: No user-controlled inputs used in run: commands.
+
+jobs:
+  stale:
+    uses: Forge-Space/.github/.github/workflows/reusable-stale.yml@main


### PR DESCRIPTION
Adopts reusable PR governance (size labels + title lint) and stale bot from .github repo.