### PR TITLE
test: add bin-entries regression guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "pretest": "npm run build",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch --onlyChanged",
+    "pretest:coverage": "npm run build",
     "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "knip": "knip",
     "deps:check": "ncu",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "pretest": "npm run build",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch --onlyChanged",
     "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",

--- a/src/__tests__/bin-entries.unit.test.ts
+++ b/src/__tests__/bin-entries.unit.test.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = process.cwd();
+const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8')) as {
+  name: string;
+  bin?: string | Record<string, string>;
+  files?: string[];
+};
+
+function normalizeBin(bin: typeof pkg.bin, name: string): Array<[string, string]> {
+  if (typeof bin === 'string') return [[name, bin]];
+  if (bin && typeof bin === 'object') return Object.entries(bin);
+  return [];
+}
+
+function pkgFilesCoversPath(files: string[], relPath: string): boolean {
+  const clean = relPath.replace(/^\.\//, '');
+  const top = clean.split('/')[0];
+  return files.some((f) => {
+    const c = f.replace(/\/$/, '').replace(/^\.\//, '');
+    return c === top;
+  });
+}
+
+describe('package.json bin entries', () => {
+  const entries = normalizeBin(pkg.bin, pkg.name);
+  const files: string[] = pkg.files ?? [];
+
+  it('declares at least one bin entry', () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it.each(entries)('bin "%s" -> "%s" exists on disk', (_name, rel) => {
+    const abs = join(repoRoot, rel.replace(/^\.\//, ''));
+    expect(existsSync(abs)).toBe(true);
+  });
+
+  it.each(entries)('bin "%s" -> "%s" starts with a node shebang', (_name, rel) => {
+    const abs = join(repoRoot, rel.replace(/^\.\//, ''));
+    if (!existsSync(abs)) return;
+    const firstLine = readFileSync(abs, 'utf-8').split('\n', 1)[0] ?? '';
+    expect(firstLine).toMatch(/^#!.*\bnode\b/);
+  });
+
+  it.each(entries)('bin "%s" -> "%s" lives under a directory in pkg.files', (_name, rel) => {
+    expect(pkgFilesCoversPath(files, rel)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a parameterized regression test that ensures no future npm package version ships with a broken `bin` entry pointing at a non-existent file.

Iterates over every `pkg.bin` entry and asserts:
- Target file exists on disk
- Target starts with a node shebang (`#!/usr/bin/env node`)
- Target lives under a directory declared in `pkg.files`

## Motivation

Prevents the regression class that shipped in `@forgespace/core` v1.4.0–v1.14.0, where `bin.forge-patterns` pointed at a non-existent `dist/cli.js` for over a year, breaking `npx @forgespace/core forge-patterns` for every consumer. See Forge-Space/core#202.

## Test Plan

- [x] Test passes with current (correct) `package.json`
- [x] Full test suite passes (64 test suites, 858 tests)
- [x] Mutation test confirms the guard catches real bugs: reverting `bin` entry to point at `dist/does-not-exist.js` makes the test fail as expected