### PR TITLE
docs(specs): bootstrap spec and roadmap flow

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ _(none)_
 
 ## Next (proposed)
 
-- **2026-04-15-ui-mcp-roadmap-specs**  _(proposed)_  `roadmap,specs,mcp`
+- **2026-04-15-ui-mcp-roadmap-specs** _(proposed)_ `roadmap,specs,mcp`
 
 ## Recently shipped
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,15 @@
+# Roadmap - ui-mcp
+
+_Auto-regenerated 2026-04-15 from `docs/specs/`._
+
+## Now (active)
+
+_(none)_
+
+## Next (proposed)
+
+- **2026-04-15-ui-mcp-roadmap-specs**  _(proposed)_  `roadmap,specs,mcp`
+
+## Recently shipped
+
+_(none)_

--- a/docs/specs/2026-04-15-ui-mcp-roadmap-specs/spec.md
+++ b/docs/specs/2026-04-15-ui-mcp-roadmap-specs/spec.md
@@ -1,0 +1,21 @@
+---
+status: proposed
+created: 2026-04-15
+owner: lucassantana
+pr:
+tags: roadmap,specs,mcp
+---
+
+# ui-mcp-roadmap-specs
+
+## Goal
+Make UIForge MCP roadmap work resumable through per-feature specs and generated roadmap state.
+
+## Context
+UIForge MCP changes often span server behavior, UI verification, and deployment checks. Specs keep those acceptance criteria durable.
+
+## Approach
+Seed one proposed spec for spec adoption, generate docs/roadmap.md, and require future multi-step MCP work to start from a spec.
+
+## Verification
+The roadmap lists this proposed spec and context-pack can retrieve it by repo and source type.

--- a/docs/specs/2026-04-15-ui-mcp-roadmap-specs/spec.md
+++ b/docs/specs/2026-04-15-ui-mcp-roadmap-specs/spec.md
@@ -9,13 +9,21 @@ tags: roadmap,specs,mcp
 # ui-mcp-roadmap-specs
 
 ## Goal
-Make UIForge MCP roadmap work resumable through per-feature specs and generated roadmap state.
+
+Make UIForge MCP roadmap work resumable through per-feature specs and generated
+roadmap state.
 
 ## Context
-UIForge MCP changes often span server behavior, UI verification, and deployment checks. Specs keep those acceptance criteria durable.
+
+UIForge MCP changes often span server behavior, UI verification, and deployment
+checks. Specs keep those acceptance criteria durable.
 
 ## Approach
-Seed one proposed spec for spec adoption, generate docs/roadmap.md, and require future multi-step MCP work to start from a spec.
+
+Seed one proposed spec for spec adoption, generate docs/roadmap.md, and require
+future multi-step MCP work to start from a spec.
 
 ## Verification
-The roadmap lists this proposed spec and context-pack can retrieve it by repo and source type.
+
+The roadmap lists this proposed spec and context-pack can retrieve it by repo
+and source type.

--- a/docs/specs/2026-04-15-ui-mcp-roadmap-specs/tasks.md
+++ b/docs/specs/2026-04-15-ui-mcp-roadmap-specs/tasks.md
@@ -1,0 +1,7 @@
+# Tasks - ui-mcp-roadmap-specs
+
+- [ ] Review current roadmap/backlog signals for the repo
+- [ ] Convert the next non-trivial feature into a focused spec
+- [ ] Keep docs/roadmap.md generated from specs, not hand-edited
+- [ ] Verify RAG returns this spec via source_type=spec or roadmap
+- [ ] Link the implementation PR before marking shipped


### PR DESCRIPTION
## Summary
- seed Agent-OS-style feature spec placeholder
- generate docs/roadmap.md from spec frontmatter
- make the repo visible to the shared RAG spec/roadmap workflow

## Verification
- formatted generated markdown with Prettier
- docs-only change