### PR TITLE
docs(specs): bootstrap spec + roadmap flow

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,4 @@
-# Roadmap - ui-mcp
+# Roadmap — ui-mcp
 
 _Auto-regenerated 2026-04-15 from `docs/specs/`._
 
@@ -8,7 +8,8 @@ _(none)_
 
 ## Next (proposed)
 
-- **2026-04-15-ui-mcp-roadmap-specs** _(proposed)_ `roadmap,specs,mcp`
+- **2026-04-15-ui-mcp-roadmap-specs**  _(proposed)_  `roadmap,specs,mcp`
+- **2026-04-15-roadmap-placeholder**  _(proposed)_  `placeholder`
 
 ## Recently shipped
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,8 +8,8 @@ _(none)_
 
 ## Next (proposed)
 
-- **2026-04-15-ui-mcp-roadmap-specs**  _(proposed)_  `roadmap,specs,mcp`
-- **2026-04-15-roadmap-placeholder**  _(proposed)_  `placeholder`
+- **2026-04-15-ui-mcp-roadmap-specs** _(proposed)_ `roadmap,specs,mcp`
+- **2026-04-15-roadmap-placeholder** _(proposed)_ `placeholder`
 
 ## Recently shipped
 

--- a/docs/specs/2026-04-15-roadmap-placeholder/spec.md
+++ b/docs/specs/2026-04-15-roadmap-placeholder/spec.md
@@ -1,0 +1,15 @@
+---
+status: proposed
+created: 2026-04-15
+owner: lucassantana
+pr:
+tags: placeholder
+---
+
+# roadmap-placeholder
+
+## Goal
+Bootstrap the spec + roadmap workflow for ui-mcp. Future feature work uses `docs/specs/<date>-<slug>/{spec,tasks}.md` with YAML frontmatter and regenerates `docs/roadmap.md` from spec `status:`.
+
+## Next
+Replace this placeholder with real proposed / active / shipped specs as work lands. See companion repo `ai-dev-toolkit/kit/specs/README.md` for the tooling (`python3 ~/.claude/rag-index/specs.py new|list|ship|roadmap`).

--- a/docs/specs/2026-04-15-roadmap-placeholder/spec.md
+++ b/docs/specs/2026-04-15-roadmap-placeholder/spec.md
@@ -9,7 +9,13 @@ tags: placeholder
 # roadmap-placeholder
 
 ## Goal
-Bootstrap the spec + roadmap workflow for ui-mcp. Future feature work uses `docs/specs/<date>-<slug>/{spec,tasks}.md` with YAML frontmatter and regenerates `docs/roadmap.md` from spec `status:`.
+
+Bootstrap the spec + roadmap workflow for ui-mcp. Future feature work uses
+`docs/specs/<date>-<slug>/{spec,tasks}.md` with YAML frontmatter and regenerates
+`docs/roadmap.md` from spec `status:`.
 
 ## Next
-Replace this placeholder with real proposed / active / shipped specs as work lands. See companion repo `ai-dev-toolkit/kit/specs/README.md` for the tooling (`python3 ~/.claude/rag-index/specs.py new|list|ship|roadmap`).
+
+Replace this placeholder with real proposed / active / shipped specs as work
+lands. See companion repo `ai-dev-toolkit/kit/specs/README.md` for the tooling
+(`python3 ~/.claude/rag-index/specs.py new|list|ship|roadmap`).

--- a/docs/specs/2026-04-15-roadmap-placeholder/tasks.md
+++ b/docs/specs/2026-04-15-roadmap-placeholder/tasks.md
@@ -1,0 +1,3 @@
+# Tasks — roadmap-placeholder
+
+- [ ] Replace placeholder with real specs as they land.


### PR DESCRIPTION
Seeds the per-feature spec + derived roadmap flow (see companion `ai-dev-toolkit/kit/specs/README.md`). One placeholder spec + auto-generated `docs/roadmap.md`. Docs only. No runtime impact.